### PR TITLE
Use Azure Key Vault to sign JARs

### DIFF
--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -21,7 +21,11 @@ jobs:
       TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
       MavenSettings: ${{ secrets.JAVA_STAGING_SETTINGS_BASE64 }}
       JavaGpgKeyPassphrase: ${{ secrets.JAVA_GPG_KEY_PASSPHRASE }}
-      CodeSigningCert: ${{ secrets.CODE_SIGNING_CERT }}
       JavaPGP: ${{ secrets.JAVA_KEY_PGP_FILE }}
-      CodeSigningCertAlias: ${{ secrets.CODE_SIGNING_CERT_ALIAS }}
-      CodeSigningCertPassword: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+      CodeSigningKeyVaultName: ${{ secrets.CODE_SIGNING_KEY_VAULT_NAME }}
+      CodeSigningKeyVaultUrl: ${{ secrets.CODE_SIGNING_KEY_VAULT_URL }}
+      CodeSigningKeyVaultClientId: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_ID }}
+      CodeSigningKeyVaultTenantId: ${{ secrets.CODE_SIGNING_KEY_VAULT_TENANT_ID }}
+      CodeSigningKeyVaultClientSecret: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_SECRET }}
+      CodeSigningKeyVaultCertificateName: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_NAME }}
+      CodeSigningKeyVaultCertificateData: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_DATA }}

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -29,7 +29,22 @@ foreach($file in $Files){
     Copy-Item -Path $file -Destination "$BinariesPath/$($file.Name)"
 }
 
-./java/build-package.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Version $Version -ExtraArgs "-DskipNativeBuild=true" -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] -CodeSigningCert $Keys['CodeSigningCert'] -JavaPGP $Keys['JavaPGP'] -CodeSigningCertAlias $Keys['CodeSigningCertAlias'] -CodeSigningCertPassword $Keys['CodeSigningCertPassword'] -MavenSettings $Keys['MavenSettings'] 
+./java/build-package.ps1 `
+    -RepoName $RepoName `
+    -ProjectDir $ProjectDir `
+    -Name $Name `
+    -Version $Version `
+    -ExtraArgs "-DskipNativeBuild=true" `
+    -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] `
+    -JavaPGP $Keys['JavaPGP'] `
+    -CodeSigningKeyVaultName: $Keys['CodeSigningKeyVaultName'] `
+    -CodeSigningKeyVaultUrl $Keys['CodeSigningKeyVaultUrl'] `
+    -CodeSigningKeyVaultClientId $Keys['CodeSigningKeyVaultClientId'] `
+    -CodeSigningKeyVaultTenantId $Keys['CodeSigningKeyVaultTenantId'] `
+    -CodeSigningKeyVaultClientSecret $Keys['CodeSigningKeyVaultClientSecret'] `
+    -CodeSigningKeyVaultCertificateName $Keys['CodeSigningKeyVaultCertificateName'] `
+    -CodeSigningKeyVaultCertificateData $Keys['CodeSigningKeyVaultCertificateData'] `
+    -MavenSettings $Keys['MavenSettings'] 
 
 
 exit $LASTEXITCODE

--- a/pom.xml
+++ b/pom.xml
@@ -256,10 +256,20 @@
                 </executions>
                 <configuration>
                     <skip>${skippackagesign}</skip>
-                    <keystore>${keystore}</keystore>
-                    <alias>${alias}</alias>
-                    <storepass>${keystorepass}</storepass>
-                    <keypass>${keypass}</keypass>
+                    <keystore>NONE</keystore>
+                    <storetype>AZUREKEYVAULT</storetype>
+                    <alias>${keyvaultCertName}</alias>
+                    <storepass>${keyvaultAccessToken}</storepass>
+                    <providerClass>net.jsign.jca.JsignJcaProvider</providerClass>
+                    <providerArg>${keyvaultVaultName}</providerArg>
+                    <tsa>http://timestamp.globalsign.com/tsa/r6advanced1</tsa>
+                    <certchain>${keyvaultCertChain}</certchain>
+                    <arguments>
+                        <argument>-J-cp</argument>
+                        <argument>-J${keyvaultJcaJar}</argument>
+                        <argument>-J--add-modules</argument>
+                        <argument>-Jjava.sql</argument>
+                    </arguments>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Changes
- Use JSign as JCA Provider for signing JARs.
- Update the list of passed through secrets.

### Why
- https://github.com/postindustria-tech/51degrees-issues/issues/50

### Dependencies
- https://github.com/51Degrees/common-ci/pull/87