### PR TITLE
add special evidence into evidence key filter

### DIFF
--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/Constants.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/Constants.java
@@ -56,4 +56,21 @@ public class Constants {
 			"carried out in order to find a match. This is the number of nodes " +
 			"in the graph which have been visited.";
 	}
+
+	private static final String ghev = "gethighentropyvalues";
+	public static final String EVIDENCE_COOKIE_GHEV =
+			fiftyone.pipeline.core.Constants.EVIDENCE_COOKIE_PREFIX +
+					fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
+					fiftyone.pipeline.engines.Constants.FIFTYONE_COOKIE_PREFIX + ghev;
+	public static final String EVIDENCE_QUERY_GHEV = fiftyone.pipeline.core.Constants.EVIDENCE_QUERY_PREFIX +
+			fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
+			fiftyone.pipeline.engines.Constants.FIFTYONE_COOKIE_PREFIX + ghev;
+
+	private static final String sua = "structureduseragent";
+	public static final String EVIDENCE_COOKIE_SUA = fiftyone.pipeline.core.Constants.EVIDENCE_COOKIE_PREFIX +
+			fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
+			fiftyone.pipeline.engines.Constants.FIFTYONE_COOKIE_PREFIX + sua;
+	public static final String EVIDENCE_QUERY_SUA = fiftyone.pipeline.core.Constants.EVIDENCE_QUERY_PREFIX +
+			fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
+			fiftyone.pipeline.engines.Constants.FIFTYONE_COOKIE_PREFIX + sua;
 }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/DeviceDetectionHashEngine.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/DeviceDetectionHashEngine.java
@@ -350,9 +350,15 @@ public class DeviceDetectionHashEngine
 
     private void setEngineMetaData() {
         evidenceKeys = getKeysFromEngine(engine);
+        evidenceKeys.add(Constants.EVIDENCE_COOKIE_GHEV);
+        evidenceKeys.add(Constants.EVIDENCE_QUERY_GHEV);
+        evidenceKeys.add(Constants.EVIDENCE_COOKIE_SUA);
+        evidenceKeys.add(Constants.EVIDENCE_QUERY_SUA);
+
         evidenceKeyFilter = new EvidenceKeyFilterWhitelist(
             evidenceKeys,
             String.CASE_INSENSITIVE_ORDER);
+
         propertiesPopulated = false;
         // Populate these data file properties from the native engine.
         FiftyOneDataFile dataFileMetaData =

--- a/device-detection.hash.engine.on-premise/src/test/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/EngineTests.java
+++ b/device-detection.hash.engine.on-premise/src/test/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/EngineTests.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
-import fiftyone.devicedetection.shared.testhelpers.FileUtils;
 import fiftyone.pipeline.engines.Constants;
 import static fiftyone.devicedetection.shared.testhelpers.FileUtils.LITE_HASH_DATA_FILE_NAME;
 import static fiftyone.devicedetection.shared.testhelpers.FileUtils.TAC_HASH_DATA_FILE_NAME;
@@ -42,56 +41,70 @@ public class EngineTests {
 
 	private DeviceDetectionHashEngine createEngine(File dataFile) throws Exception {
 		return new DeviceDetectionHashEngineBuilder(loggerFactory, null)
-                .setPerformanceProfile(Constants.PerformanceProfiles.HighPerformance)
-                .setUpdateMatchedUserAgent(true)
-                .setAutoUpdate(false)
-                .build(dataFile.toString(), false);
+				.setPerformanceProfile(Constants.PerformanceProfiles.HighPerformance)
+				.setUpdateMatchedUserAgent(true)
+				.setAutoUpdate(false)
+				.build(dataFile.toString(), false);
 	}
-	
+
 	/**
 	 * Shared method for dataDataSourceTier tests.
+	 *
 	 * @param fileName
 	 * @throws Exception
 	 */
 	private void testDataSourceTier(String fileName) throws Exception {
-		File dataFile = null;
-		try {
-			dataFile = getFilePath(fileName);
-		}
-		catch (IllegalArgumentException e) {
-			assumeTrue(e.getMessage(), false);
-		}
-		
-		DeviceDetectionHashEngine engine = createEngine(dataFile);
+		DeviceDetectionHashEngine engine = createEngine(fileName);
+		assertTrue(engine.getEvidenceKeyFilter().include(
+				fiftyone.devicedetection.hash.engine.onpremise.flowelements.Constants.EVIDENCE_QUERY_GHEV));
+		assertTrue(engine.getEvidenceKeyFilter().include(
+				fiftyone.devicedetection.hash.engine.onpremise.flowelements.Constants.EVIDENCE_COOKIE_GHEV));
+		assertTrue(engine.getEvidenceKeyFilter().include(
+				fiftyone.devicedetection.hash.engine.onpremise.flowelements.Constants.EVIDENCE_QUERY_SUA));
+		assertTrue(engine.getEvidenceKeyFilter().include(
+				fiftyone.devicedetection.hash.engine.onpremise.flowelements.Constants.EVIDENCE_COOKIE_SUA));
+
 		String tier = engine.getDataSourceTier();
 		engine.close();
-		
+
 		if (fileName.equals(LITE_HASH_DATA_FILE_NAME)) {
 			assertEquals("Lite", tier);
-		}
-		else {
+		} else {
 			assertTrue(tier.equalsIgnoreCase("Enterprise") ||
 					tier.equalsIgnoreCase("TAC"));
 		}
 	}
-	
+
+	private DeviceDetectionHashEngine createEngine(String fileName) throws Exception {
+		File dataFile = null;
+		try {
+			dataFile = getFilePath(fileName);
+		} catch (IllegalArgumentException e) {
+			assumeTrue(e.getMessage(), false);
+		}
+
+		DeviceDetectionHashEngine engine = createEngine(dataFile);
+		return engine;
+	}
+
 	/**
 	 * Check that getDataSourceTier returns correct product for Lite data file
+	 *
 	 * @throws Exception
 	 */
 	@Test
 	public void Engine_Hash_GetDataSourceTier_Lite() throws Exception {
 		testDataSourceTier(LITE_HASH_DATA_FILE_NAME);
 	}
-	
+
 	/**
 	 * Check that getDataSourceTier returns correct product for Enterprise data
 	 * file
+	 *
 	 * @throws Exception
 	 */
 	@Test
 	public void Engine_Hash_GetDataSourceTier_Enterprise() throws Exception {
 		testDataSourceTier(TAC_HASH_DATA_FILE_NAME);
 	}
-
 }


### PR DESCRIPTION
This is needed in order to use `51d_gethighenropyvalues` and `51d_structureduseragent` in the examples.  Resolves https://github.com/51Degrees/device-detection-java/issues/260