### PR TITLE
ci: cross-compile for ARM if Zig is installed

### DIFF
--- a/ci/options.json
+++ b/ci/options.json
@@ -16,6 +16,8 @@
     "Name": "Ubuntu_Java_11",
     "JavaSDKEnvVar": "JAVA_HOME_11_X64",
     "RunPerformance": true,
+    "Language": "zig",
+    "LanguageVersion": "0.13.0",
     "PackageRequirement" : true
   },
   {

--- a/device-detection.hash.engine.on-premise/src/main/cxx/PreBuild.sh
+++ b/device-detection.hash.engine.on-premise/src/main/cxx/PreBuild.sh
@@ -18,4 +18,13 @@ if [[ $OSTYPE == darwin* ]]; then
 	cmake ../../src/main/cxx -DARCH=aarch64 -DCMAKE_OSX_ARCHITECTURES=arm64 -DBUILD_TESTING=OFF
 	echo "cmake build"
 	cmake --build . --target fiftyone-hash-java
+elif [[ $OSTYPE == linux* ]] && command -v zig >/dev/null; then
+	echo "additional ARM64 build"
+	export CC="zig cc -target aarch64-linux-gnu.2.26 -s" CXX="zig c++ -target aarch64-linux-gnu.2.26 -s"
+	echo "configure"
+	sed -i '/^if (NOT MSVC AND NOT APPLE)/,/^endif()/s/^/#/' ../../src/main/cxx/device-detection-cxx/src/common-cxx/CMakeLists.txt # 🤡
+	cmake ../../src/main/cxx -DARCH=aarch64 -DBUILD_TESTING=OFF --fresh
+	echo "cmake build"
+	cmake --build . --target fiftyone-hash-java --clean-first
+	sed -i '/^#if (NOT MSVC AND NOT APPLE)/,/^#endif()/s/^#//' ../../src/main/cxx/device-detection-cxx/src/common-cxx/CMakeLists.txt # 🤡
 fi


### PR DESCRIPTION
On Linux. For macOS this was already implemented, as the toolchain there natively supports cross-compilation.

Depends on: https://github.com/51Degrees/common-ci/commit/164829d9f19e030379c41a9f9773591860d71fd9