### PR TITLE
ci: use zig for glibc cross-compilation on x86 too

### DIFF
--- a/ci/options.json
+++ b/ci/options.json
@@ -23,8 +23,6 @@
     "Name": "Ubuntu_ARM_Java_11",
     "JavaSDKEnvVar": "JAVA_HOME_11_X64",
     "RunPerformance": true,
-    "Language": "zig",
-    "LanguageVersion": "0.13.0",
     "PackageRequirement" : true
   },
   {

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -5,6 +5,15 @@ param(
     [string]$JavaSDKEnvVar,
     [string]$ProjectDir = "."
 )
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+if ($IsLinux -and -not (Get-Command zig -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing zig for glibc cross-compilation..."
+    New-Item -ItemType Directory -Force ~/.local/bin, ~/.local/opt/zig | Out-Null
+    curl -sSL --fail-with-body 'https://github.com/51Degrees/common-ci/releases/download/zig/zig-linux-x86_64-0.13.0.tar.xz' | tar -xJ --strip-components=1 -C ~/.local/opt/zig
+    New-Item -ItemType SymbolicLink -Path ~/.local/bin/zig -Target ~/.local/opt/zig/zig | Out-Null
+}
 
 ./java/setup-enviroment.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -JavaSDKEnvVar $JavaSDKEnvVar
 

--- a/device-detection.hash.engine.on-premise/src/main/cxx/PreBuild.sh
+++ b/device-detection.hash.engine.on-premise/src/main/cxx/PreBuild.sh
@@ -2,12 +2,12 @@
 set -eu
 
 # A client uses Amazon Linux 2 based container with glibc 2.26. Until they
-# update we use Zig as a C/C++ cross-compiler to target that glibc version. Only
-# for ARM, as that's the platform the client is currently using.
-if [[ $OSTYPE == linux* && $(uname -m) == aarch64 ]] && command -v zig >/dev/null; then
+# update we use Zig as a C/C++ cross-compiler to target that glibc version.
+if [[ $OSTYPE == linux* ]] && command -v zig >/dev/null; then
 	echo "using zig cc to target GLIBC 2.26"
-	export CC="zig cc -target aarch64-linux-gnu.2.26 -s" CXX="zig c++ -target aarch64-linux-gnu.2.26 -s"
-	export CMAKE_LIBRARY_PATH=/lib/aarch64-linux-gnu
+	export CC="zig cc -target native-linux-gnu.2.26 -s" CXX="zig c++ -target native-linux-gnu.2.26 -s"
+	# Help CMake find libatomic on ARM, even though we shouldn't need it with Zig:
+	case $(uname -m) in aarch64) export CMAKE_LIBRARY_PATH=/lib/aarch64-linux-gnu; esac
 fi
 
 # mvn clean will delete target so that's the place to be building


### PR DESCRIPTION
Zig is downloaded from common-ci releases mirror to avoid straining official/community servers.

Closes: #277