### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=java-open-source "Data rewards the curious") **Java Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=top "Data rewards the curious") **Java Device Detection**
 
-[Developer Documentation](https://51degrees.com/device-detection-java/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=java-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-java/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 
@@ -10,8 +10,8 @@ This repository contains Java implementation of the device detection [specificat
 
 ## Dependencies
 
-For runtime dependencies, see our [dependencies](http://51degrees.com/documentation/_info__dependencies.html) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=dependencies) page.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=dependencies) page shows 
 the JDK versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -21,9 +21,9 @@ The Java API can either use our cloud service to get its data or it can use a lo
 
 #### Cloud
 
-You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=cloud)
 to use the Cloud API, as described on our website. Get resource keys from
-our [configurator](https://configure.51degrees.com/), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html) on 
+our [configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=cloud), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=cloud) on 
 how to use this.
 
 #### On-Premise
@@ -32,7 +32,7 @@ If you are using on-premise detection, a "Lite" version of the data required is 
 in this repository. It contains only a limited set of "essential" device detection properties. 
 
 You may want to license our complete data file containing all properties. 
-[Details of our licenses](https://51degrees.com/pricing) are available on our website.
+[Details of our licenses](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=on-premise) are available on our website.
 
 If you want to use the lite file, you will need to install [GitLFS](https://git-lfs.github.com/), then:
 
@@ -163,7 +163,7 @@ repository.
 
 ## Tests
 
-You will need [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
+You will need [resource keys](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=readme.md&utm_term=tests)
 (see above) to complete the tests and run examples which include exercising the cloud API.
 
 To verify the code:

--- a/ci/README.md
+++ b/ci/README.md
@@ -6,11 +6,11 @@ The following secrets are required:
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
   
 The following secrets are required to run on-premise tests:
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
  
 The following secrets are requred to run cloud tests:
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
 
 The following secrets are required for publishing releases (this should only be needed by 51Degrees):

--- a/device-detection.cloud/pom.xml
+++ b/device-detection.cloud/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>device-detection.cloud</artifactId>
     <name>51Degrees :: Device Detection :: Cloud</name>
     <description>Cloud-based device detection for Java that uses the 51Degrees cloud service via the Pipeline API. Parses HTTP headers to identify device hardware, operating systems, browsers, and crawlers.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.cloud-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/device-detection.hash.engine.on-premise/pom.xml
+++ b/device-detection.hash.engine.on-premise/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>device-detection.hash.engine.on-premise</artifactId>
     <name>51Degrees :: Device Detection :: Hash :: On Premise</name>
 	<description>High-performance on-premise hash-based device detection engine for Java, built for the 51Degrees Pipeline API. Parses HTTP headers locally to identify device hardware, operating systems, browsers, and crawlers, with no external service calls.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/DeviceDetectionHashEngineBuilder.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/flowelements/DeviceDetectionHashEngineBuilder.java
@@ -187,7 +187,7 @@ public class DeviceDetectionHashEngineBuilder
      * Provide a hint as to how many threads will access the pipeline simultaneously
      * <p>
      * Default is the result of {@link Runtime#getRuntime()#getAvailableProcessors()}
-     * @see <a href="https://51degrees.com/documentation/_device_detection__features__concurrent_processing.html">Concurrent processing</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__features__concurrent_processing.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-src-main-java-fiftyone-devicedetection-hash-engine-onpremise-flowelements-devicedetectionhashenginebuilder.java&amp;utm_term=setconcurrency">Concurrent processing</a>
      * @param concurrency expected concurrent accesses
      * @return this builder
      */
@@ -202,7 +202,7 @@ public class DeviceDetectionHashEngineBuilder
      * Whether to return a default profile if no match
      * <p>
      * Default false
-     * @see <a href="https://51degrees.com/documentation/_device_detection__features__false_positive_control.html">No Match Found</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__features__false_positive_control.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-src-main-java-fiftyone-devicedetection-hash-engine-onpremise-flowelements-devicedetectionhashenginebuilder.java&amp;utm_term=setallowunmatched">No Match Found</a>
      * @param allow true if results with no matched hash nodes should be
      *              considered valid
      * @return this builder
@@ -219,7 +219,7 @@ public class DeviceDetectionHashEngineBuilder
      * slightly from what is expected.
      * <p>
      * Default is 0.
-     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-src-main-java-fiftyone-devicedetection-hash-engine-onpremise-flowelements-devicedetectionhashenginebuilder.java&amp;utm_term=setdifference#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
      * @param difference to allow
      * @return this builder
      */
@@ -236,7 +236,7 @@ public class DeviceDetectionHashEngineBuilder
      * returned.
      * <p>
      * Default is 0.
-     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-src-main-java-fiftyone-devicedetection-hash-engine-onpremise-flowelements-devicedetectionhashenginebuilder.java&amp;utm_term=setdrift#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
      * @param drift to set
      * @return this builder
      */
@@ -256,7 +256,7 @@ public class DeviceDetectionHashEngineBuilder
      * next if there was no match in the performance graph.
      * <p>
      * Default is false
-     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-src-main-java-fiftyone-devicedetection-hash-engine-onpremise-flowelements-devicedetectionhashenginebuilder.java&amp;utm_term=setuseperformancegraph#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
      * @param use true if the performance graph should be used
      * @return this builder
      */
@@ -275,7 +275,7 @@ public class DeviceDetectionHashEngineBuilder
      * consideration.
      * <p>
      * Default is true
-     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.hash.engine.on-premise-src-main-java-fiftyone-devicedetection-hash-engine-onpremise-flowelements-devicedetectionhashenginebuilder.java&amp;utm_term=setusepredictivegraph#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
      * @param use true if the predictive graph should be used
      * @return this builder
      */

--- a/device-detection.shared/pom.xml
+++ b/device-detection.shared/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>device-detection.shared</artifactId>
     <name>51Degrees :: Device Detection :: Shared</name>
     <description>Shared components and utilities for building 51Degrees Pipeline API device detection engines in Java. Supports parsing HTTP headers to identify device type, model, OS, browser, and crawler information—an alternative approach to UAParser, DeviceAtlas, and WURFL-based solutions.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection.shared-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/device-detection/pom.xml
+++ b/device-detection/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>device-detection</artifactId>
     <name>51Degrees :: Device Detection</name>
     <description>Parse HTTP headers to detect the device type, model, OS, browser, and crawler information. This is an alternative to popular UAParser, DeviceAtlas, and WURFL packages.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/device-detection/src/main/java/fiftyone/devicedetection/DeviceDetectionOnPremisePipelineBuilder.java
+++ b/device-detection/src/main/java/fiftyone/devicedetection/DeviceDetectionOnPremisePipelineBuilder.java
@@ -339,7 +339,7 @@ public class DeviceDetectionOnPremisePipelineBuilder
      * match for evidence which was not in the training data. If
      * the predictive graph is also enabled, it will be used
      * next if there was no match in the performance graph.
-     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance">Hash Algorithm</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection-src-main-java-fiftyone-devicedetection-devicedetectiononpremisepipelinebuilder.java&amp;utm_term=setuseperformancegraph#DeviceDetection_Hash_DataSetProduction_Performance">Hash Algorithm</a>
      * @param use true if the performance graph should be used
      * @return this builder
      */
@@ -355,7 +355,7 @@ public class DeviceDetectionOnPremisePipelineBuilder
      * which was not in the training data. However, this is at the
      * expense of processing time, as more possibilities are taken into
      * consideration.
-     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=device-detection-java&amp;utm_content=device-detection-src-main-java-fiftyone-devicedetection-devicedetectiononpremisepipelinebuilder.java&amp;utm_term=setusepredictivegraph#DeviceDetection_Hash_DataSetProduction_Predictive">Hash Algorithm</a>
      * @param use true if the predictive graph should be used
      * @return this builder
      */

--- a/device-detection/src/main/java/fiftyone/devicedetection/DeviceDetectionPipelineBuilder.java
+++ b/device-detection/src/main/java/fiftyone/devicedetection/DeviceDetectionPipelineBuilder.java
@@ -145,7 +145,7 @@ public class DeviceDetectionPipelineBuilder {
     /**
      * Use the 51Degrees Cloud service to perform device detection.
      * @param resourceKey The resource key to use when querying the cloud service. 
-     * Obtain one from https://configure.51degrees.com
+     * Obtain one from https://configure.51degrees.com?utm_source=code&utm_medium=comment&utm_campaign=device-detection-java&utm_content=device-detection-src-main-java-fiftyone-devicedetection-devicedetectionpipelinebuilder.java&utm_term=usecloud
      * @return A builder that can be used to configure and build a pipeline
      * that will use the cloud device detection engine.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <name>51Degrees :: Pipeline :: Device Detection</name>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=device-detection-java&amp;utm_content=pom.xml&amp;utm_term=url</url>
     <description>Device detection engines for the 51Degrees Pipeline API</description>
 
     <modules>


### PR DESCRIPTION
Apply the standard UTM vocabulary to navigational 51degrees.com and configure.51degrees.com links so the Content Team can trace traffic to its exact source.

## What changed

- `utm_source` = `github` for markdown, `code` for Java comments/javadoc, `maven` for `pom.xml` `<url>` package metadata.
- `utm_medium` = `readme` for README files, `comment` for library source, `package` for `pom.xml`.
- `utm_campaign` = `device-detection-java`.
- `utm_content` = file path slug.
- `utm_term` = location within the file (nearest heading, enclosing member).
- Normalised `http` to `https`, and stale `/documentation/4.4/` paths to the un-versioned `/documentation/`.
- Replaced the old `utm_campaign=java-open-source` README logo/documentation scheme.

## Not changed

- `scm`/`developerConnection` git URL and the `engineering@51degrees.com` email in the root `pom.xml`.
- The `distributor.51degrees.com` download endpoint in `ci/README.md` (functional host).
- Test fixture host string in `CloudRequestOriginTests.java`.
- The `device-detection-cxx` submodule (empty on this checkout).

A `utm-link-lint` GitHub Actions workflow is added in a separate commit to keep these links conformant going forward.
