### PR TITLE
FIX: Fix compiler warnings and enable -Werror

### DIFF
--- a/device-detection.cloud/src/main/java/fiftyone/devicedetection/cloud/data/MultiDeviceDataCloud.java
+++ b/device-detection.cloud/src/main/java/fiftyone/devicedetection/cloud/data/MultiDeviceDataCloud.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * Encapsulates a list of {@link DeviceData} instances which can be returned
  * by the 51Degrees cloud service when certain evidence is provided (e.g. TAC)
  */
-public class MultiDeviceDataCloud
+public final class MultiDeviceDataCloud
     extends AspectDataBase
     implements MultiProfileData<DeviceData> {
     private static final String DEVICE_LIST_KEY = "profiles";

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/CollectionConfigSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/CollectionConfigSwig.java
@@ -21,7 +21,7 @@ public class CollectionConfigSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ComponentMetaDataCollectionSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ComponentMetaDataCollectionSwig.java
@@ -21,7 +21,7 @@ public class ComponentMetaDataCollectionSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ComponentMetaDataSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ComponentMetaDataSwig.java
@@ -21,7 +21,7 @@ public class ComponentMetaDataSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ConfigBaseSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ConfigBaseSwig.java
@@ -21,7 +21,7 @@ public class ConfigBaseSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ConfigDeviceDetectionSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ConfigDeviceDetectionSwig.java
@@ -20,7 +20,7 @@ public class ConfigDeviceDetectionSwig extends ConfigBaseSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ConfigHashSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ConfigHashSwig.java
@@ -20,7 +20,7 @@ public class ConfigHashSwig extends ConfigDeviceDetectionSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/Date.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/Date.java
@@ -21,7 +21,7 @@ public class Date {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/EngineBaseSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/EngineBaseSwig.java
@@ -21,7 +21,7 @@ public class EngineBaseSwig implements AutoCloseable {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/EngineDeviceDetectionSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/EngineDeviceDetectionSwig.java
@@ -20,7 +20,7 @@ public class EngineDeviceDetectionSwig extends EngineBaseSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/EngineHashSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/EngineHashSwig.java
@@ -20,7 +20,7 @@ public class EngineHashSwig extends EngineDeviceDetectionSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/MapStringStringSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/MapStringStringSwig.java
@@ -145,7 +145,7 @@ public class MapStringStringSwig extends java.util.AbstractMap<String, String> i
       return (obj == null) ? 0 : obj.swigCPtr;
     }
   
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     protected void finalize() {
       delete();
     }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/MetaDataSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/MetaDataSwig.java
@@ -21,7 +21,7 @@ public class MetaDataSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ProfileMetaDataCollectionSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ProfileMetaDataCollectionSwig.java
@@ -21,7 +21,7 @@ public class ProfileMetaDataCollectionSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ProfileMetaDataSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ProfileMetaDataSwig.java
@@ -21,7 +21,7 @@ public class ProfileMetaDataSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/PropertyMetaDataCollectionSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/PropertyMetaDataCollectionSwig.java
@@ -21,7 +21,7 @@ public class PropertyMetaDataCollectionSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/PropertyMetaDataSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/PropertyMetaDataSwig.java
@@ -21,7 +21,7 @@ public class PropertyMetaDataSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/RequiredPropertiesConfigSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/RequiredPropertiesConfigSwig.java
@@ -21,7 +21,7 @@ public class RequiredPropertiesConfigSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ValueMetaDataCollectionSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ValueMetaDataCollectionSwig.java
@@ -21,7 +21,7 @@ public class ValueMetaDataCollectionSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ValueMetaDataKeySwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ValueMetaDataKeySwig.java
@@ -21,7 +21,7 @@ public class ValueMetaDataKeySwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ValueMetaDataSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/ValueMetaDataSwig.java
@@ -21,7 +21,7 @@ public class ValueMetaDataSwig {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }

--- a/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/VectorStringSwig.java
+++ b/device-detection.hash.engine.on-premise/src/main/java/fiftyone/devicedetection/hash/engine/onpremise/interop/swig/VectorStringSwig.java
@@ -36,6 +36,7 @@ public class VectorStringSwig extends java.util.AbstractList<String> implements 
     this.delete();
   }
 
+  @SuppressWarnings("this-escape")
   public VectorStringSwig(String[] initialElements) {
     this();
     reserve(initialElements.length);
@@ -45,6 +46,7 @@ public class VectorStringSwig extends java.util.AbstractList<String> implements 
     }
   }
 
+  @SuppressWarnings("this-escape")
   public VectorStringSwig(Iterable<String> initialElements) {
     this();
     for (String element : initialElements) {

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
                             <arg>-Xlint:all,-try,-options</arg>
-<!--                            <arg>-Werror</arg>-->
+                            <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
JDK 21+ surfaces two lint categories the build did not previously act on. This change clears them across all modules and turns on warnings as errors to prevent regressions.
Finalize deprecated for removal (20 SWIG-generated classes): On JDK 21+ java.lang.Object.finalize is annotated deprecated for removal, so the warning belongs to the "removal" lint category. The existing @SuppressWarnings("deprecation") does not cover that category, so it is widened to @SuppressWarnings({"deprecation", "removal"}), which is also what current SWIG emits.

Possible 'this' escape before a subclass is fully initialised: MultiDeviceDataCloud is now final. Its constructors call the overridable put method, inherited from DataBase, before the object is fully built, which is exactly the hazard the lint flags. Marking the class final removes any possibility of a subclass override running against a half constructed instance, so javac no longer reports the escape and no suppression is required.
VectorStringSwig is SWIG-generated, so any edit to it is overwritten the next time the native build regenerates the bindings. Its two constructors therefore keep a narrow @SuppressWarnings("this-escape") as a stopgap.

Enable -Werror:
The javac -Werror argument in the root pom maven-compiler-plugin configuration is uncommented, so any warning now fails the build. Verified by compiling the full reactor, all four modules including main and test sources, on JDK 25 with -Werror, which succeeds with no warnings reported.

Closes #363 