### PR TITLE
FIX: Bump device-detection-cxx and align tests to unified result shape

### DIFF
--- a/device-detection.hash.engine.on-premise/src/test/java/fiftyone/devicedetection/hash/engine/onpremise/data/DataValidatorHash.java
+++ b/device-detection.hash.engine.on-premise/src/test/java/fiftyone/devicedetection/hash/engine/onpremise/data/DataValidatorHash.java
@@ -29,6 +29,7 @@ import fiftyone.devicedetection.shared.testhelpers.data.DataValidator;
 import fiftyone.pipeline.core.data.FlowData;
 import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.exceptions.NoValueException;
+import fiftyone.pipeline.engines.fiftyone.data.ComponentMetaData;
 import fiftyone.pipeline.engines.fiftyone.data.FiftyOneAspectPropertyMetaData;
 
 import java.util.Arrays;
@@ -81,13 +82,28 @@ public class DataValidatorHash implements DataValidator {
         if (validEvidence == false) {
             assertEquals("0-0-0-0", elementData.getDeviceId().getValue());
         }
-        int validKeys = 0;
-        for (String key : data.getEvidence().asKeyMap().keySet()) {
-            if (engine.getEvidenceKeyFilter().include(key)) {
-                validKeys++;
-            }
+        // Since the detection result shape was unified in device-detection-cxx
+        // (issue #362), the number of results - and therefore the number of
+        // matched User-Agents - is determined by the components the engine can
+        // populate, not by how many evidence keys were supplied. Supplying
+        // redundant evidence no longer changes it. The exact number depends on
+        // which components the data file makes available, so assert the bound
+        // rather than a fixed value, and that valid evidence produces at least
+        // one result.
+        int componentCount = 0;
+        for (ComponentMetaData component : engine.getComponents()) {
+            componentCount++;
         }
-        assertEquals("validKeys vs userAgents size mismatch", validKeys, elementData.getUserAgents().getValue().size());
+        int matchedUserAgents = elementData.getUserAgents().getValue().size();
+        assertTrue(
+            "There should be no more matched User-Agents (" + matchedUserAgents +
+                ") than components populated by the engine (" + componentCount + ")",
+            matchedUserAgents <= componentCount);
+        if (validEvidence) {
+            assertTrue(
+                "Valid evidence should produce at least one result",
+                matchedUserAgents >= 1);
+        }
     }
 
     @Override

--- a/device-detection.shared/src/test/java/fiftyone/devicedetection/shared/testhelpers/data/ValueTests.java
+++ b/device-detection.shared/src/test/java/fiftyone/devicedetection/shared/testhelpers/data/ValueTests.java
@@ -30,6 +30,7 @@ import fiftyone.pipeline.core.data.ElementPropertyMetaData;
 import fiftyone.pipeline.core.data.FlowData;
 import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.exceptions.PropertyMissingException;
+import fiftyone.pipeline.engines.fiftyone.data.ComponentMetaData;
 import fiftyone.pipeline.engines.fiftyone.data.FiftyOneAspectPropertyMetaData;
 
 import java.lang.reflect.Method;
@@ -59,7 +60,21 @@ public class ValueTests {
                 .process();
             ElementData elementData = data.get(wrapper.getEngine().getElementDataKey());
             DeviceData device = (DeviceData) elementData;
-            assertEquals(1, device.getUserAgents().getValue().size());
+            // Since the detection result shape was unified in
+            // device-detection-cxx (issue #362), a single User-Agent produces
+            // one result - and so one matched User-Agent - per component the
+            // engine populates, rather than exactly one overall. The number
+            // depends on the data file, so assert the bound here and validate
+            // every matched substring below.
+            int componentCount = 0;
+            for (ComponentMetaData component : wrapper.getComponents()) {
+                componentCount++;
+            }
+            int matchedCount = device.getUserAgents().getValue().size();
+            assertTrue(
+                "Expected between 1 and " + componentCount +
+                    " matched User-Agents, got " + matchedCount,
+                matchedCount >= 1 && matchedCount <= componentCount);
             for (String matchedUa : device.getUserAgents().getValue()) {
                 for (String substring : matchedUa.split("_|\\{|\\}")) {
                     if (substring.isEmpty() == false) {


### PR DESCRIPTION
Relates to #TASK

Picks up the `device-detection-cxx` change that unified the detection result
shape (51Degrees/device-detection-cxx#362, merged in
51Degrees/device-detection-cxx#385) and updates the two test assertions that
encoded the removed fast path.

The submodule bump and the test updates have to land together: the new
assertions do not hold against the previous native library, and the old ones do
not hold against the new one.

## Why the nightly failed

The nightly on #558 reported 3 failures out of 33 in
`51Degrees :: Device Detection :: Hash :: On Premise`
([run](https://github.com/51Degrees/device-detection-java/actions/runs/29978606597/job/89115752895)):

```
ValueHashTests.Values_Hash_MatchedUserAgents:159   expected:<1> but was:<4>
TestProcessTests.Process_Hash_CaseInsensitiveKeys:67  validKeys vs userAgents size mismatch expected:<1> but was:<4>
TestProcessTests.Process_Hash_EmptyUserAgent:52       validKeys vs userAgents size mismatch expected:<1> but was:<4>
```

Both assertions tied the result shape to evidence cardinality, which is exactly
the coupling #362 removed:

- `DataValidatorHash` counted the accepted evidence keys and asserted one
  matched User-Agent per key.
- `ValueTests.matchedUserAgents` asserted exactly one.

Detection now produces one result per component the engine populates, so a
single User-Agent yields 4 rather than 1. These are the intended consequence of
the native change, not new defects.

## Changes

- Bump `device-detection-cxx` to `c7b2822` (includes #362 / #385).
- `DataValidatorHash` — replace the per-evidence-key equality with a bound (no
  more matched User-Agents than components the engine populates) plus "valid
  evidence yields at least one result".
- `ValueTests.matchedUserAgents` (shared test helpers) — same bound. The
  per-entry check that every matched substring really occurs at the expected
  offset in the original User-Agent is untouched; that is the substantive
  assertion.

The counts are deliberately asserted as a bound rather than a fixed number: the
exact value is "components that have available properties", which depends on the
data file. Pinning a literal would make the tests brittle across data file
revisions. This also brings the on-premise helper into line with the cloud
`ValueTests.matchedUserAgents`, which already asserts a range rather than an
exact count.

Only the on-premise path is affected — `ValueCloudTests` imports the cloud
module's own `ValueTests`, which is unchanged.

## Verification

Built the native engine against the new submodule and ran the tests on Windows
x64 (JDK 17):

- `device-detection.hash.engine.on-premise`: **33 tests, 0 failures** (was 3
  failures)
- `device-detection.shared`: 3 tests, 0 failures

## Behaviour change to be aware of

#362 is an observable change for on-premise consumers, and this PR is where it
reaches Java:

- The number of entries in `getUserAgents()` (and match metrics derived from the
  result list) is now determined by the data file's components, not by how many
  evidence pairs were supplied. Redundant evidence no longer changes it.
- With `allowUnmatched` enabled, components with no matched profile are filled
  with each component's default profile, matching evidence-based processing.

Please call these out in the release notes. The same change is landing in
device-detection-dotnet, and the other on-premise language bindings will need
the equivalent test updates as their submodule PRs land.

## Supersedes

Replaces the automated submodule PR #558, which cannot go green on its own
because it carries the bump without the matching test updates. Close #558 when
this merges.
