### PR TITLE
DOCS: Describe granting native library access

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,31 @@ and also add a transitive dependency these jars need (would have been added by M
     <version>4.5.x</version>
 </dependency>
 ```
+## Native library access
+
+On-premise device detection loads a native library through `System.load`, which recent
+JDKs treat as a restricted method and will eventually block
+(see [JEP 472](https://openjdk.org/jeps/472)). The load is performed by `LibLoader` in
+`pipeline.engines.fiftyone`, so the permission is granted against that package.
+
+If the 51Degrees JARs are on the **classpath** (the usual setup):
+
+```bash
+java -cp "libs/*" --enable-native-access=ALL-UNNAMED com.example.Main
+```
+
+If the pipeline JARs are on the **module path**, you can grant native access to
+51Degrees code alone instead of to everything unnamed:
+
+```bash
+java --module-path libs --enable-native-access=fiftyone.pipeline.engines.fiftyone -m your.app/com.example.Main
+```
+
+The device detection packages themselves are not named modules and need no changes -
+unnamed modules can read named ones. See the
+[pipeline-java README](https://github.com/51Degrees/pipeline-java#java-modules-and-native-library-access)
+for the full list of module names and the caveats that apply on the module path.
+
 ## Examples
 
 Examples can be found in

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ jars - and only those two - onto the module path, leaving your application and e
 other dependency on the classpath:
 
 ```bash
-java -cp "libs/*" --module-path "mods/*" --add-modules fiftyone.pipeline.engines.fiftyone,fiftyone.devicedetection.hash.engine.onpremise --enable-native-access=fiftyone.pipeline.engines.fiftyone,fiftyone.devicedetection.hash.engine.onpremise com.example.Main
+java -cp "libs/*" --module-path mods --add-modules fiftyone.pipeline.engines.fiftyone,fiftyone.devicedetection.hash.engine.onpremise --enable-native-access=fiftyone.pipeline.engines.fiftyone,fiftyone.devicedetection.hash.engine.onpremise com.example.Main
 ```
 
 A jar must not appear on both paths, so keep the two module path jars in a separate

--- a/README.md
+++ b/README.md
@@ -192,12 +192,29 @@ java -cp "libs/*" --module-path "mods/*" --add-modules fiftyone.pipeline.engines
 A jar must not appear on both paths, so keep the two module path jars in a separate
 directory from the classpath ones.
 
-Both names come from an `Automatic-Module-Name` manifest entry, so the jars remain
-ordinary non-modular jars and nothing changes for consumers who stay on the classpath.
-See the
+### Module names
+
+Every package in this repository declares a module name, not just the two above. Only
+`fiftyone.devicedetection.hash.engine.onpremise` is needed for native access; the rest
+are named so that the name stays stable for anyone who puts them on the module path.
+
+| Package | Module name |
+|---|---|
+| device-detection | `fiftyone.devicedetection` |
+| device-detection.cloud | `fiftyone.devicedetection.cloud` |
+| device-detection.hash.engine.on-premise | `fiftyone.devicedetection.hash.engine.onpremise` |
+| device-detection.shared | `fiftyone.devicedetection.shared` |
+
+Without a declared name the module system derives one from the file name, which gives
+`device.detection.hash.engine.on.premise` and changes whenever the artifact is renamed
+or shaded.
+
+The names come from an `Automatic-Module-Name` manifest entry, so the jars remain
+ordinary non-modular jars, build identically on every JDK from 8 upwards, and nothing
+changes for consumers who stay on the classpath. See the
 [pipeline-java README](https://github.com/51Degrees/pipeline-java#native-library-access)
-for the other 51Degrees module names and for how to configure element builders when a
-jar is on the module path.
+for the pipeline module names and for how to configure element builders when a jar is on
+the module path.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -157,28 +157,47 @@ and also add a transitive dependency these jars need (would have been added by M
 ```
 ## Native library access
 
-On-premise device detection loads a native library through `System.load`, which recent
-JDKs treat as a restricted method and will eventually block
-(see [JEP 472](https://openjdk.org/jeps/472)). The load is performed by `LibLoader` in
-`pipeline.engines.fiftyone`, so the permission is granted against that package.
+On-premise device detection uses a native library, and
+[JEP 472](https://openjdk.org/jeps/472) restricts two things it needs: calling
+`System.load`, and binding a JNI `native` method declaration to its implementation.
+Java 24 and 25 warn once per calling module, and a later release will refuse the call
+and throw `IllegalCallerException`.
 
-If the 51Degrees JARs are on the **classpath** (the usual setup):
+The two operations happen in **different** packages:
+
+| Restricted operation | Declared in | Module name |
+|---|---|---|
+| `System.load` | `pipeline.engines.fiftyone` | `fiftyone.pipeline.engines.fiftyone` |
+| JNI `native` methods | `device-detection.hash.engine.on-premise` | `fiftyone.devicedetection.hash.engine.onpremise` |
+
+### On the classpath
+
+This is the default layout and needs no changes to how you package or deploy. One flag
+covers both operations:
 
 ```bash
 java -cp "libs/*" --enable-native-access=ALL-UNNAMED com.example.Main
 ```
 
-If the pipeline JARs are on the **module path**, you can grant native access to
-51Degrees code alone instead of to everything unnamed:
+### Naming 51Degrees code alone
+
+If granting native access to every jar on the classpath is too broad, move those two
+jars - and only those two - onto the module path, leaving your application and every
+other dependency on the classpath:
 
 ```bash
-java --module-path libs --enable-native-access=fiftyone.pipeline.engines.fiftyone -m your.app/com.example.Main
+java -cp "libs/*" --module-path "mods/*" --add-modules fiftyone.pipeline.engines.fiftyone,fiftyone.devicedetection.hash.engine.onpremise --enable-native-access=fiftyone.pipeline.engines.fiftyone,fiftyone.devicedetection.hash.engine.onpremise com.example.Main
 ```
 
-The device detection packages themselves are not named modules and need no changes -
-unnamed modules can read named ones. See the
-[pipeline-java README](https://github.com/51Degrees/pipeline-java#java-modules-and-native-library-access)
-for the full list of module names and the caveats that apply on the module path.
+A jar must not appear on both paths, so keep the two module path jars in a separate
+directory from the classpath ones.
+
+Both names come from an `Automatic-Module-Name` manifest entry, so the jars remain
+ordinary non-modular jars and nothing changes for consumers who stay on the classpath.
+See the
+[pipeline-java README](https://github.com/51Degrees/pipeline-java#native-library-access)
+for the other 51Degrees module names and for how to configure element builders when a
+jar is on the module path.
 
 ## Examples
 

--- a/device-detection.cloud/pom.xml
+++ b/device-detection.cloud/pom.xml
@@ -44,4 +44,28 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <!-- Names this jar as an automatic module, so that
+                                         the name stays stable if it is put on the
+                                         module path. -->
+                                    <Automatic-Module-Name>fiftyone.devicedetection.cloud</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/device-detection.hash.engine.on-premise/pom.xml
+++ b/device-detection.hash.engine.on-premise/pom.xml
@@ -150,6 +150,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <!-- Names this jar as an automatic module. The JNI
+                                         native method declarations live here, and JEP 472
+                                         checks binding them against the module that
+                                         declares them, so this name is needed alongside
+                                         fiftyone.pipeline.engines.fiftyone. -->
+                                    <Automatic-Module-Name>fiftyone.devicedetection.hash.engine.onpremise</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/device-detection.shared/pom.xml
+++ b/device-detection.shared/pom.xml
@@ -34,6 +34,19 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <!-- Names this jar as an automatic module, so that
+                                         the name stays stable if it is put on the
+                                         module path. -->
+                                    <Automatic-Module-Name>fiftyone.devicedetection.shared</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>Jar Tests Package</id>
                         <phase>package</phase>
                         <goals>

--- a/device-detection/pom.xml
+++ b/device-detection/pom.xml
@@ -53,4 +53,28 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <!-- Names this jar as an automatic module, so that
+                                         the name stays stable if it is put on the
+                                         module path. -->
+                                    <Automatic-Module-Name>fiftyone.devicedetection</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Device detection half of #476.

[JEP 472](https://openjdk.org/jeps/472) restricts two operations that on-premise device
detection needs, and they are declared in **different** repositories:

| Restricted operation | Declared in | Module name |
|---|---|---|
| `System.load` | `pipeline.engines.fiftyone` | `fiftyone.pipeline.engines.fiftyone` |
| JNI `native` methods | `device-detection.hash.engine.on-premise` | `fiftyone.devicedetection.hash.engine.onpremise` |

All 264 `native` declarations in this repository are in
`DeviceDetectionHashEngineModuleJNI`, so granting only the pipeline module would leave a
second warning coming from device detection's own code.

## Changes

Adds `Automatic-Module-Name` to all four packages. Only the on-premise engine needs one
for native access; the rest are named so that the name stays stable for anyone who puts
them on the module path, rather than being derived from the file name:

| Package | Declared | Derived from filename if undeclared |
|---|---|---|
| device-detection | `fiftyone.devicedetection` | `device.detection` |
| device-detection.cloud | `fiftyone.devicedetection.cloud` | `device.detection.cloud` |
| device-detection.hash.engine.on-premise | `fiftyone.devicedetection.hash.engine.onpremise` | `device.detection.hash.engine.on.premise` |
| device-detection.shared | `fiftyone.devicedetection.shared` | `device.detection.shared` |

Also adds a **Native library access** section to the README covering the classpath case
(`--enable-native-access=ALL-UNNAMED`, unchanged and still the default), the module path
case naming both restricted modules, and the module name table.

No source changes. `Automatic-Module-Name` is a plain manifest entry, so the jars stay
ordinary non-modular jars, build identically on every JDK from 8 upwards, and nothing
changes for consumers who stay on the classpath.

## Verification

Built offline with `-DskipNativeBuild=true`; all four manifests confirmed with
`jar --describe-module`. Checked there are no split packages between the four packages,
so the distinct names are safe.

Not verified: the JNI binding restriction ships in JDK 24 and only JDK 17 was available,
so the second module name is added on the basis of where the `native` declarations live
rather than an observed warning.

Depends on the companion pipeline-java PR (51Degrees/pipeline-java#106), which adds the
README section this one links to; merge that first.
